### PR TITLE
Add jsk_visualization_msgs

### DIFF
--- a/jsk_visualization_msgs/CMakeLists.txt
+++ b/jsk_visualization_msgs/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(jsk_visualization_msgs)
+
+find_package(catkin REQUIRED COMPONENTS
+  geometry_msgs
+  message_generation
+  std_msgs
+)
+
+add_message_files(
+  FILES
+  ObjectFitCommand.msg
+  OverlayMenu.msg
+  OverlayText.msg
+  PictogramArray.msg
+  Pictogram.msg
+  RecordCommand.msg
+  StringStamped.msg
+  TransformableMarkerOperate.msg
+)
+
+add_service_files(
+  FILES
+  EusCommand.srv
+  RequestMarkerOperate.srv
+  Screenshot.srv
+)
+
+generate_messages(
+  DEPENDENCIES
+  geometry_msgs
+  std_msgs
+)
+
+catkin_package(
+  CATKIN_DEPENDS
+  message_runtime
+)

--- a/jsk_visualization_msgs/msg/ObjectFitCommand.msg
+++ b/jsk_visualization_msgs/msg/ObjectFitCommand.msg
@@ -1,0 +1,8 @@
+uint8 FIT=0
+uint8 NEAR=1
+uint8 OTHER=2
+uint8 REVERSE_FIT=3
+uint8 REVERSE_NEAR=4
+uint8 REVERSE_OTHER=5
+
+int8 command

--- a/jsk_visualization_msgs/msg/OverlayMenu.msg
+++ b/jsk_visualization_msgs/msg/OverlayMenu.msg
@@ -1,0 +1,6 @@
+int32 ACTION_SELECT=0
+int32 ACTION_CLOSE=1
+int32 action
+uint32 current_index
+string[] menus
+string title

--- a/jsk_visualization_msgs/msg/OverlayText.msg
+++ b/jsk_visualization_msgs/msg/OverlayText.msg
@@ -1,0 +1,17 @@
+uint8 ADD = 0
+uint8 DELETE = 1
+
+uint8 action
+
+int32 width
+int32 height
+int32 left
+int32 top
+std_msgs/ColorRGBA bg_color
+
+int32 line_width
+float32 text_size
+string font
+std_msgs/ColorRGBA fg_color
+
+string text

--- a/jsk_visualization_msgs/msg/Pictogram.msg
+++ b/jsk_visualization_msgs/msg/Pictogram.msg
@@ -1,0 +1,20 @@
+Header header
+geometry_msgs/Pose pose
+uint8 ADD=0
+uint8 DELETE=1
+uint8 ROTATE_Z=2
+uint8 ROTATE_Y=3
+uint8 ROTATE_X=4
+uint8 JUMP=5
+uint8 JUMP_ONCE=6
+uint8 action
+
+uint8 PICTOGRAM_MODE=0
+uint8 STRING_MODE=1
+
+uint8 mode
+string character
+float64 size
+float64 ttl
+float64 speed
+std_msgs/ColorRGBA color

--- a/jsk_visualization_msgs/msg/PictogramArray.msg
+++ b/jsk_visualization_msgs/msg/PictogramArray.msg
@@ -1,0 +1,2 @@
+Header header
+Pictogram[] pictograms

--- a/jsk_visualization_msgs/msg/RecordCommand.msg
+++ b/jsk_visualization_msgs/msg/RecordCommand.msg
@@ -1,0 +1,6 @@
+uint8 RECORD=0
+uint8 RECORD_STOP=1
+uint8 PLAY=2
+
+int8 command
+string target

--- a/jsk_visualization_msgs/msg/StringStamped.msg
+++ b/jsk_visualization_msgs/msg/StringStamped.msg
@@ -1,0 +1,2 @@
+Header header
+string data

--- a/jsk_visualization_msgs/msg/TransformableMarkerOperate.msg
+++ b/jsk_visualization_msgs/msg/TransformableMarkerOperate.msg
@@ -1,0 +1,18 @@
+uint8 BOX=0
+uint8 CYLINDER=1
+uint8 TORUS=2
+uint8 MESH_RESOURCE=3
+
+uint8 INSERT=0
+uint8 ERASE=1
+uint8 ERASEALL=2
+uint8 ERASEFOCUS=3
+uint8 COPY=4
+
+int32 type
+int32 action
+string frame_id
+string name
+string description
+string mesh_resource
+bool mesh_use_embedded_materials

--- a/jsk_visualization_msgs/package.xml
+++ b/jsk_visualization_msgs/package.xml
@@ -1,0 +1,16 @@
+<package>
+  <name>jsk_visualization_msgs</name>
+  <version>4.1.1</version>
+  <description>Messages used in rviz/rqt plugins at JSK Lab.</description>
+  <author email="ueda@jsk.t.u-tokyo.ac.jp">Ryohei Ueda</author>
+  <maintainer email="wada@jsk.imi.i.u-tokyo.ac.jp">Kentaro Wada</maintainer>
+
+  <license>BSD</license>
+  <url type="website">http://ros.org/wiki/jsk_visualization_msgs</url>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>message_generation</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <run_depend>message_runtime</run_depend>
+  <run_depend>geometry_msgs</run_depend>
+</package>

--- a/jsk_visualization_msgs/srv/EusCommand.srv
+++ b/jsk_visualization_msgs/srv/EusCommand.srv
@@ -1,0 +1,2 @@
+string command
+---

--- a/jsk_visualization_msgs/srv/RequestMarkerOperate.srv
+++ b/jsk_visualization_msgs/srv/RequestMarkerOperate.srv
@@ -1,0 +1,2 @@
+TransformableMarkerOperate operate
+---

--- a/jsk_visualization_msgs/srv/Screenshot.srv
+++ b/jsk_visualization_msgs/srv/Screenshot.srv
@@ -1,0 +1,2 @@
+string file_name
+---


### PR DESCRIPTION
## Why?

In order to use jsk_visualization_msgs in jsk_recognition.
Currently it is located under jsk_rviz_plugins, so it requires dependency of jsk_recognition on jsk_rviz_plugins.
But it can't be happening, because we prefer dependency graph of jsk_recognition <- jsk_visualization in most cases.
That's why I need to split ros msg/srv into some other upstream repo.