### PR TITLE
migration to opencv3

### DIFF
--- a/posedetection_msgs/include/posedetection_msgs/feature0d_to_image.h
+++ b/posedetection_msgs/include/posedetection_msgs/feature0d_to_image.h
@@ -43,6 +43,7 @@
 
 #include <opencv/cv.hpp>
 #include <opencv2/highgui/highgui.hpp>
+#include <opencv2/videoio.hpp>
 #include <boost/shared_ptr.hpp>
 
 #include <message_filters/subscriber.h>


### PR DESCRIPTION
> highgui module has been split into parts: imgcodecs, videoio and highgui itself

from https://docs.opencv.org/3.1.0/db/dfa/tutorial_transition_guide.html