### PR TITLE
Add SentenceInfo.msg and WordInfo.msg

### DIFF
--- a/speech_recognition_msgs/CMakeLists.txt
+++ b/speech_recognition_msgs/CMakeLists.txt
@@ -10,8 +10,10 @@ add_message_files(
   FILES
   Grammar.msg
   PhraseRule.msg
+  SentenceInfo.msg
   SpeechRecognitionCandidates.msg
   Vocabulary.msg
+  WordInfo.msg
 )
 
 add_service_files(

--- a/speech_recognition_msgs/msg/SentenceInfo.msg
+++ b/speech_recognition_msgs/msg/SentenceInfo.msg
@@ -1,0 +1,2 @@
+Header header
+speech_recognition_msgs/WordInfo[] words

--- a/speech_recognition_msgs/msg/SpeechRecognitionCandidates.msg
+++ b/speech_recognition_msgs/msg/SpeechRecognitionCandidates.msg
@@ -1,2 +1,3 @@
 string[] transcript   # candidate words of speech-to-text API
 float32[] confidence  # confidence of transcript
+speech_recognition_msgs/SentenceInfo[] sentences  # contains the beginning and ending times of each word.

--- a/speech_recognition_msgs/msg/WordInfo.msg
+++ b/speech_recognition_msgs/msg/WordInfo.msg
@@ -1,0 +1,7 @@
+# please see below URL for more details.
+# https://cloud.google.com/speech-to-text/docs/reference/rest/v1/speech/recognize#wordinfo
+float64 start_time
+float64 end_time
+string word
+float64 confidence
+int32 speaker_tag


### PR DESCRIPTION
# What is this?

Google speech-to-text provide `WordInfo` which has `start_time`, `end_time`, `confidence` and `speaker_tag` for each words.
For more details, please see https://cloud.google.com/speech-to-text/docs/reference/rest/v1/speech/recognize#wordinfo .
This PR adds `WordInfo.msg` and `SentenceInfo.msg` and adds `SentenceInfo.msg` to `SpeechRecognitionCandidate.msg`.