### PR TITLE
[GA] add kilted/lyrical test

### DIFF
--- a/.github/workflows/ros2.yaml
+++ b/.github/workflows/ros2.yaml
@@ -7,8 +7,12 @@ on:
 jobs:
   build_and_test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ROS_DISTRO: [jazzy, kilted, lyrical]
     steps:
       - uses: actions/checkout@v4
       - uses: ros-industrial/industrial_ci@master
         env:
-          ROS_DISTRO: jazzy
+          ROS_DISTRO: ${{ matrix.ROS_DISTRO }}


### PR DESCRIPTION
to fix https://build.ros2.org/job/Lsrc_uR__posedetection_msgs__ubuntu_resolute__source/
this should reproduce something like
```
l_typesupport_fastrtps_cpp -isystem /opt/ros/lyrical/include/rosidl_buffer_backend -isystem /opt/ros/lyrical/include/rmw -isystem /opt/ros/lyrical/include/rosidl_dynamic_typesupport -isystem /opt/ros/lyrical/include/rosidl_typesupport_fastrtps_c -isystem /opt/ros/lyrical/include/rosidl_typesupport_introspection_c -isystem /opt/ros/lyrical/include/rosidl_typesupport_introspection_cpp -isystem /usr/include/opencv4 -isystem /opt/ros/lyrical/include/rclcpp -isystem /opt/ros/lyrical/include/libstatistics_collector -isystem /opt/ros/lyrical/include/rcl -isystem /opt/ros/lyrical/include/rcl_interfaces -isystem /opt/ros/lyrical/include/rcl_logging_interface -isystem /opt/ros/lyrical/include/rcl_yaml_param_parser -isystem /opt/ros/lyrical/include/type_description_interfaces -isystem /opt/ros/lyrical/include/rcpputils -isystem /opt/ros/lyrical/include/statistics_msgs -isystem /opt/ros/lyrical/include/rosgraph_msgs -isystem /opt/ros/lyrical/include/rosidl_typesupport_cpp -isystem /opt/ros/lyrical/include/rosidl_typesupport_c -isystem /opt/ros/lyrical/include/tracetools -isystem /opt/ros/lyrical/include/message_filters -g -O2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -ffile-prefix-map=/tmp/binarydeb/ros-lyrical-posedetection-msgs-5.0.1=. -flto=auto -ffat-lto-objects -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -mbranch-protection=standard -fdebug-prefix-map=/tmp/binarydeb/ros-lyrical-posedetection-msgs-5.0.1=/usr/src/ros-lyrical-posedetection-msgs-5.0.1-3resolute.20260904.063243 -DNDEBUG -Wdate-time -D_FORTIFY_SOURCE=3 -std=gnu++20 -MD -MT CMakeFiles/feature0d_view.dir/src/feature0d_view.cpp.o -MF CMakeFiles/feature0d_view.dir/src/feature0d_view.cpp.o.d -o CMakeFiles/feature0d_view.dir/src/feature0d_view.cpp.o -c /tmp/binarydeb/ros-lyrical-posedetection-msgs-5.0.1/src/feature0d_view.cpp
In file included from /tmp/binarydeb/ros-lyrical-posedetection-msgs-5.0.1/src/feature0d_view.cpp:14:
/tmp/binarydeb/ros-lyrical-posedetection-msgs-5.0.1/include/posedetection_msgs/feature0d_to_image.h:73:10: fatal error: message_filters/subscriber.h: No such file or directory
   73 | #include <message_filters/subscriber.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[4]: *** [CMakeFiles/feature0d_view.dir/build.make:82: CMakeFiles/feature0d_view.dir/src/feature0d_view.cpp.o] Error 1
make[3]: *** [CMakeFiles/Makefile2:735: CMakeFiles/feature0d_view.dir/all] Error 2
make[4]: Leaving directory '/tmp/binarydeb/ros-lyrical-posedetection-msgs-5.0.1/.obj-aarch64-linux-gnu'
make[3]: Leaving directory '/tmp/binarydeb/ros-lyrical-posedetection-msgs-5.0.1/.obj-aarch64-linux-gnu'
make[2]: *** [Makefile:149: all] Error 2
make[2]: Leaving directory '/tmp/binarydeb/ros-lyrical-posedetection-msgs-5.0.1/.obj-aarc
```